### PR TITLE
Added compatibility with Triton

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -41,6 +41,7 @@ taboolib {
             name("ItemsAdder").optional(true)
             name("floodgate-bukkit").optional(true)
             name("FastScript").optional(true)
+            name("Triton").optional(true)
         }
     }
     relocate("trplugins.menu", group.toString().toLowerCase())
@@ -81,6 +82,8 @@ dependencies {
     compileOnly("com.github.Th0rgal:Oraxen:-SNAPSHOT") { isTransitive = false }
     compileOnly("org.black_ixx:playerpoints:3.1.1") { isTransitive = false }
     compileOnly("com.github.MilkBowl:VaultAPI:-SNAPSHOT") { isTransitive = false }
+    compileOnly("com.github.tritonmc.Triton:core:v3.7.3") { isTransitive = false }
+    compileOnly("com.github.tritonmc.Triton:api:v3.7.3") { isTransitive = false }
 
     compileOnly(fileTree("libs"))
 }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/HookPlugin.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/HookPlugin.kt
@@ -75,4 +75,8 @@ object HookPlugin {
         return get(HookZaphkiel::class.java)
     }
 
+    fun getTriton(): HookTriton {
+        return get(HookTriton::class.java)
+    }
+
 }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/impl/HookTriton.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/impl/HookTriton.kt
@@ -1,0 +1,28 @@
+package trplugins.menu.module.internal.hook.impl
+
+import com.rexcantor64.triton.Triton
+import com.rexcantor64.triton.api.players.LanguagePlayer
+import org.bukkit.entity.Player
+import trplugins.menu.module.internal.hook.HookAbstract
+
+/**
+ * @author Rubenicos
+ * @date 2022/06/01 09:18
+ */
+class HookTriton : HookAbstract() {
+
+    private val triton: Triton? = if (isHooked) Triton.get() else null
+        get() {
+            if (field == null) reportAbuse()
+            return field
+        }
+
+    fun getText(player: Player, code: String, args: Array<String>): String? {
+        val langPlayer: LanguagePlayer = triton?.playerManager?.get(player.uniqueId) ?: return null
+        return triton?.languageManager?.getText(langPlayer, code, *args)
+    }
+
+    override fun getPluginName(): String {
+        return "Triton"
+    }
+}

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
@@ -79,7 +79,7 @@ object FunctionParser {
 
     private fun parseLangText(player: Player, text: String): String {
         val split = text.split("=", limit = 2)
-        return HookPlugin.getTriton().getText(player, split[0], if (split.size < 2) emptyArray() else split[1].split("_\\|\\|_").toTypedArray()).toString()
+        return HookPlugin.getTriton().getText(player, split[0], if (split.size < 2) emptyArray() else split[1].split("_||_").toTypedArray()).toString()
     }
 
 }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
@@ -11,6 +11,7 @@ import trplugins.menu.util.print
 import org.bukkit.entity.Player
 import taboolib.common.util.subList
 import taboolib.module.configuration.Configuration
+import trplugins.menu.module.internal.hook.HookPlugin
 
 /**
  * @author Arasple
@@ -38,6 +39,7 @@ object FunctionParser {
                         "meta", "m" -> Metadata.getMeta(player)[value].toString()
                         "data", "d" -> Metadata.getData(player)[value].toString()
                         "globaldata", "gdata", "g" -> runCatching { Metadata.globalData[value].toString() }.getOrElse { "null" }
+                        "lang", "triton" -> parseLangText(player, value)
 
                         else -> block(type, value) ?: "{${it.value}}"
                     }
@@ -73,6 +75,11 @@ object FunctionParser {
 
     private fun parseJavaScript(session: MenuSession, input: String): String {
         return JavaScriptAgent.eval(session, input).asString()
+    }
+
+    private fun parseLangText(player: Player, text: String): String {
+        val split = text.split("=", limit = 2)
+        return HookPlugin.getTriton().getText(player, split[0], if (split.size < 2) emptyArray() else split[1].split("_\\|\\|_").toTypedArray()).toString()
     }
 
 }


### PR DESCRIPTION
This PR adds compatibility with the plugin [Triton](https://www.spigotmc.org/resources/triton.30331/).

You can use `{lang:ID}` or `{triton:ID}` to get translated message by ID, for example `{lang:example.translation}`.
The full usage is `{lang:ID=args}` to get translated message with args separated by `_||_`, for example `{lang:example.translation=arg 1_||_arg 2}`